### PR TITLE
Add https support to get_avatar()

### DIFF
--- a/init.php
+++ b/init.php
@@ -187,6 +187,10 @@ class basic_user_avatars {
 			$local_avatars[$size] = home_url( $local_avatars[$size] );
 		}
 
+		if ( is_ssl() ) {
+			$local_avatars[ $size ] = str_replace( 'http', 'https', $local_avatars[ $size ] );
+		}
+
 		$author_class = is_author( $user_id ) ? ' current-author' : '' ;
 		$avatar       = "<img alt='" . esc_attr( $alt ) . "' src='" . $local_avatars[$size] . "' class='avatar avatar-{$size}{$author_class} photo' height='{$size}' width='{$size}' />";
 


### PR DESCRIPTION
Resolves #12 

If `is_ssl()`, then replace the `http` with `https` in the return string in the `get_avatar()` function.