### PR TITLE
Also pass the user ID to basic_user_avatar filter

### DIFF
--- a/init.php
+++ b/init.php
@@ -194,7 +194,7 @@ class basic_user_avatars {
 		$author_class = is_author( $user_id ) ? ' current-author' : '' ;
 		$avatar       = "<img alt='" . esc_attr( $alt ) . "' src='" . $local_avatars[$size] . "' class='avatar avatar-{$size}{$author_class} photo' height='{$size}' width='{$size}' />";
 
-		return apply_filters( 'basic_user_avatar', $avatar );
+		return apply_filters( 'basic_user_avatar', $avatar, $user_id );
 	}
 
 	/**


### PR DESCRIPTION
The `basic_user_avatar` filter isn't very useful, because you just get a blob of HTML and you have no idea what user it's for. This adds `$user_id` to the filter, so you could re-fetch the user meta and re-create the HTML however you wanted.

My use case for this is to append a user-meta-stored version number to the `src` so that browser caches are immediately invalidated when a user updates their avatar.