### PR TITLE
Fix deletion of old avatars before upload of new

### DIFF
--- a/init.php
+++ b/init.php
@@ -349,7 +349,7 @@ class basic_user_avatars {
 			if ( ! function_exists( 'wp_handle_upload' ) )
 				require_once ABSPATH . 'wp-admin/includes/file.php';
 
-			$this->avatar_delete( $this->user_id_being_edited );
+			$this->avatar_delete( $user_id );
 
 			// Need to be more secure since low privelege users can upload
 			if ( strstr( $_FILES['basic-user-avatar']['name'], '.php' ) )


### PR DESCRIPTION
The current code uses `$this->user_id_being_edited` as the argument to `$this->avatar_delete` on line 352, but it does not set this value until line 359. This means that `avatar_delete` is always getting a `null` user and never actually deleting anything.

This change uses `$user_id` as the argument instead, which allows the plugin to delete the old avatars before uploading the new.

Given the text in the description of what will happen on the profile page ("Replace the local avatar by uploading a new avatar"), deleting the old avatars would be the expected behavior. We want to _replace_ the local avatar, not leave it lingering in the uploads directory. This pull request accomplishes the result promised in the description.